### PR TITLE
Wait for document ready before doing things

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -31,8 +31,10 @@ module.exports = Franz => {
   const getMessages = () => Franz.setBadge(updates);
 
   modal = createModal();
-  document.body.appendChild(modal);
-  document.addEventListener('keydown', event => event.keyCode === 27 && hideModal());
+  document.addEventListener("DOMContentLoaded", function(event) {
+    document.body.appendChild(modal);
+    document.addEventListener('keydown', event => event.keyCode === 27 && hideModal());
+  });
 
   Franz.injectCSS(path.join(__dirname, 'calendar.css'));
   Franz.loop(getMessages);

--- a/webview.js
+++ b/webview.js
@@ -31,7 +31,7 @@ module.exports = Franz => {
   const getMessages = () => Franz.setBadge(updates);
 
   modal = createModal();
-  document.addEventListener("DOMContentLoaded", function(event) {
+  document.addEventListener('DOMContentLoaded', event => {
     document.body.appendChild(modal);
     document.addEventListener('keydown', event => event.keyCode === 27 && hideModal());
   });


### PR DESCRIPTION
This came up from discussion in meetfranz/franz#1223. In situations where Google Calendar loads slowly, these two actions (`appendChild` and `addEventListener`) generate exceptions because the document is not ready. I am reasonably certain those exceptions cause any darkmode.css (meetfranz/franz#960) to not be injected (probably related to #3 ). When applying this patch I am able to successfully render Google Calendar with darkmode.

![franz](https://user-images.githubusercontent.com/505621/53361261-5c706400-3905-11e9-8d14-474b2f959deb.PNG)
