### PR TITLE
Force the calendar to show desktop version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Rico Herwig <rherwig4711@gmail.com>",
     "license": "MIT",
     "config": {
-        "serviceURL": "https://calendar.google.com/calendar",
+        "serviceURL": "https://calendar.google.com/calendar/render",
         "hasNotificationSound": true,
         "hasDirectMessages": true,
         "openDevTools": true


### PR DESCRIPTION
Hello,

the calendar is always loaded in the mobile version for me (unusable and thus I need to switch to the desktop one manually all the time - after each service reload). I've added this quick fix to force it to use the desktop version instead of the mobile one. 

It can be useful for others too. Consider adding it.

Thanks for the plugin!

V.

